### PR TITLE
Remove Dependabot Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,6 @@ NestJS-Ethers
 [![CircleCI](https://circleci.com/gh/jarcodallo/nestjs-ethers/tree/main.svg?style=svg)](https://circleci.com/gh/jarcodallo/nestjs-ethers/tree/main)
 [![Coverage Status](https://coveralls.io/repos/github/jarcodallo/nestjs-ethers/badge.svg?branch=main)](https://coveralls.io/github/jarcodallo/nestjs-ethers?branch=main)
 [![vulnerabilities](https://img.shields.io/snyk/vulnerabilities/npm/nestjs-ethers)](https://snyk.io/test/github/jarcodallo/nestjs-ethers)
-[![dependencies](https://img.shields.io/david/jarcodallo/nestjs-ethers)](https://img.shields.io/david/jarcodallo/nestjs-ethers)
-[![dependabot](https://badgen.net/dependabot/jarcodallo/nestjs-ethers/?icon=dependabot)](https://badgen.net/dependabot/jarcodallo/nestjs-ethers/?icon=dependabot)
 [![supported platforms](https://img.shields.io/badge/platforms-Express%20%26%20Fastify-green)](https://img.shields.io/badge/platforms-Express%20%26%20Fastify-green)
 
 


### PR DESCRIPTION
## PR Checklist

Remove Dependabot badge that has been broken since the migration to GitHub-native Dependabot dependabot/dependabot-core#1912

- [ ] The commit message follows our guidelines: https://github.com/jarcodallo/nestjs-ethers/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] CI related changes

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
