### PR TITLE
Add module context token

### DIFF
--- a/__tests__/ethers.contract.spec.ts
+++ b/__tests__/ethers.contract.spec.ts
@@ -2,13 +2,20 @@ import { Module, Controller, Get, Injectable } from '@nestjs/common'
 import { NestFactory } from '@nestjs/core'
 import * as nock from 'nock'
 import * as request from 'supertest'
-import { EthersModule, EthersContract, SmartContract, EthersSigner } from '../src'
+import {
+  EthersModule,
+  EthersContract,
+  Contract,
+  EthersSigner,
+  InjectContractProvider,
+  InjectSignerProvider,
+} from '../src'
 import * as ABI from './utils/ABI.json'
 import { ETHERS_ADDRESS, ETHERS_PRIVATE_KEY } from './utils/constants'
 import { extraWait } from './utils/extraWait'
 import { platforms } from './utils/platforms'
 
-describe('EthersSigner', () => {
+describe('EthersContract', () => {
   beforeEach(() => nock.cleanAll())
 
   beforeAll(() => {
@@ -26,105 +33,242 @@ describe('EthersSigner', () => {
 
   for (const PlatformAdapter of platforms) {
     describe(PlatformAdapter.name, () => {
-      it('should create an instance of the SmartContract attached to an address with a provider injected', async () => {
-        @Injectable()
-        class TestService {
-          constructor(private readonly ethersContract: EthersContract) {}
-          async someMethod(): Promise<string> {
-            const contract: SmartContract = this.ethersContract.create(ETHERS_ADDRESS, ABI)
+      describe('forRoot', () => {
+        it('should create an instance of the SmartContract attached to an address with a provider injected', async () => {
+          @Injectable()
+          class TestService {
+            constructor(
+              @InjectContractProvider()
+              private readonly contract: EthersContract,
+            ) {}
+            async someMethod(): Promise<string> {
+              const contract: Contract = this.contract.create(ETHERS_ADDRESS, ABI)
 
-            if (!contract?.provider?.getNetwork()) {
-              throw new Error('No provider injected')
+              if (!contract?.provider?.getNetwork()) {
+                throw new Error('No provider injected')
+              }
+
+              return contract.address
             }
-
-            return contract.address
           }
-        }
 
-        @Controller('/')
-        class TestController {
-          constructor(private readonly service: TestService) {}
-          @Get()
-          async get() {
-            const address = await this.service.someMethod()
+          @Controller('/')
+          class TestController {
+            constructor(private readonly service: TestService) {}
+            @Get()
+            async get() {
+              const address = await this.service.someMethod()
 
-            return { address: address.toLowerCase() }
+              return { address: address.toLowerCase() }
+            }
           }
-        }
 
-        @Module({
-          imports: [EthersModule.forRoot()],
-          controllers: [TestController],
-          providers: [TestService],
-        })
-        class TestModule {}
-
-        const app = await NestFactory.create(TestModule, new PlatformAdapter(), { logger: false })
-        const server = app.getHttpServer()
-
-        await app.init()
-        await extraWait(PlatformAdapter, app)
-        await request(server)
-          .get('/')
-          .expect(200)
-          .expect((res) => {
-            expect(res.body).toHaveProperty('address', ETHERS_ADDRESS)
+          @Module({
+            imports: [EthersModule.forRoot()],
+            controllers: [TestController],
+            providers: [TestService],
           })
+          class TestModule {}
 
-        await app.close()
+          const app = await NestFactory.create(TestModule, new PlatformAdapter(), { logger: false })
+          const server = app.getHttpServer()
+
+          await app.init()
+          await extraWait(PlatformAdapter, app)
+          await request(server)
+            .get('/')
+            .expect(200)
+            .expect((res) => {
+              expect(res.body).toHaveProperty('address', ETHERS_ADDRESS)
+            })
+
+          await app.close()
+        })
+
+        it('should be able to set a Wallet into a SmartContract', async () => {
+          @Injectable()
+          class TestService {
+            constructor(
+              @InjectContractProvider()
+              private readonly contract: EthersContract,
+              @InjectSignerProvider()
+              private readonly signer: EthersSigner,
+            ) {}
+            async someMethod(): Promise<string> {
+              const wallet = this.signer.createWallet(ETHERS_PRIVATE_KEY)
+              const contract: Contract = this.contract.create(ETHERS_ADDRESS, ABI, wallet)
+
+              if (!contract?.provider?.getNetwork()) {
+                throw new Error('No provider injected')
+              }
+
+              if (!contract?.signer.provider?.getNetwork()) {
+                throw new Error('No signer injected')
+              }
+
+              return contract.address
+            }
+          }
+
+          @Controller('/')
+          class TestController {
+            constructor(private readonly service: TestService) {}
+            @Get()
+            async get() {
+              const address = await this.service.someMethod()
+
+              return { address: address.toLowerCase() }
+            }
+          }
+
+          @Module({
+            imports: [EthersModule.forRoot()],
+            controllers: [TestController],
+            providers: [TestService],
+          })
+          class TestModule {}
+
+          const app = await NestFactory.create(TestModule, new PlatformAdapter(), { logger: false })
+          const server = app.getHttpServer()
+
+          await app.init()
+          await extraWait(PlatformAdapter, app)
+          await request(server)
+            .get('/')
+            .expect(200)
+            .expect((res) => {
+              expect(res.body).toHaveProperty('address', ETHERS_ADDRESS)
+            })
+
+          await app.close()
+        })
       })
 
-      it('should be able to set a Wallet into a SmartContract', async () => {
-        @Injectable()
-        class TestService {
-          constructor(private readonly ethersContract: EthersContract, private readonly ethersSigner: EthersSigner) {}
-          async someMethod(): Promise<string> {
-            const wallet = this.ethersSigner.createWallet(ETHERS_PRIVATE_KEY)
-            const contract: SmartContract = this.ethersContract.create(ETHERS_ADDRESS, ABI, wallet)
+      describe('forRootAsync', () => {
+        it('should create an instance of the SmartContract attached to an address with a provider injected', async () => {
+          @Injectable()
+          class TestService {
+            constructor(
+              @InjectContractProvider()
+              private readonly contract: EthersContract,
+            ) {}
+            async someMethod(): Promise<string> {
+              const contract: Contract = this.contract.create(ETHERS_ADDRESS, ABI)
 
-            if (!contract?.provider?.getNetwork()) {
-              throw new Error('No provider injected')
+              if (!contract?.provider?.getNetwork()) {
+                throw new Error('No provider injected')
+              }
+
+              return contract.address
             }
+          }
 
-            if (!contract?.signer.provider?.getNetwork()) {
-              throw new Error('No signer injected')
+          @Controller('/')
+          class TestController {
+            constructor(private readonly service: TestService) {}
+            @Get()
+            async get() {
+              const address = await this.service.someMethod()
+
+              return { address: address.toLowerCase() }
             }
-
-            return contract.address
           }
-        }
 
-        @Controller('/')
-        class TestController {
-          constructor(private readonly service: TestService) {}
-          @Get()
-          async get() {
-            const address = await this.service.someMethod()
-
-            return { address: address.toLowerCase() }
-          }
-        }
-
-        @Module({
-          imports: [EthersModule.forRoot()],
-          controllers: [TestController],
-          providers: [TestService],
-        })
-        class TestModule {}
-
-        const app = await NestFactory.create(TestModule, new PlatformAdapter(), { logger: false })
-        const server = app.getHttpServer()
-
-        await app.init()
-        await extraWait(PlatformAdapter, app)
-        await request(server)
-          .get('/')
-          .expect(200)
-          .expect((res) => {
-            expect(res.body).toHaveProperty('address', ETHERS_ADDRESS)
+          @Module({
+            imports: [
+              EthersModule.forRootAsync({
+                useFactory: () => {
+                  return {
+                    useDefaultProvider: true,
+                  }
+                },
+              }),
+            ],
+            controllers: [TestController],
+            providers: [TestService],
           })
+          class TestModule {}
 
-        await app.close()
+          const app = await NestFactory.create(TestModule, new PlatformAdapter(), { logger: false })
+          const server = app.getHttpServer()
+
+          await app.init()
+          await extraWait(PlatformAdapter, app)
+          await request(server)
+            .get('/')
+            .expect(200)
+            .expect((res) => {
+              expect(res.body).toHaveProperty('address', ETHERS_ADDRESS)
+            })
+
+          await app.close()
+        })
+
+        it('should be able to set a Wallet into a SmartContract', async () => {
+          @Injectable()
+          class TestService {
+            constructor(
+              @InjectContractProvider()
+              private readonly contract: EthersContract,
+              @InjectSignerProvider()
+              private readonly signer: EthersSigner,
+            ) {}
+            async someMethod(): Promise<string> {
+              const wallet = this.signer.createWallet(ETHERS_PRIVATE_KEY)
+              const contract: Contract = this.contract.create(ETHERS_ADDRESS, ABI, wallet)
+
+              if (!contract?.provider?.getNetwork()) {
+                throw new Error('No provider injected')
+              }
+
+              if (!contract?.signer.provider?.getNetwork()) {
+                throw new Error('No signer injected')
+              }
+
+              return contract.address
+            }
+          }
+
+          @Controller('/')
+          class TestController {
+            constructor(private readonly service: TestService) {}
+            @Get()
+            async get() {
+              const address = await this.service.someMethod()
+
+              return { address: address.toLowerCase() }
+            }
+          }
+
+          @Module({
+            imports: [
+              EthersModule.forRootAsync({
+                useFactory: () => {
+                  return {
+                    useDefaultProvider: true,
+                  }
+                },
+              }),
+            ],
+            controllers: [TestController],
+            providers: [TestService],
+          })
+          class TestModule {}
+
+          const app = await NestFactory.create(TestModule, new PlatformAdapter(), { logger: false })
+          const server = app.getHttpServer()
+
+          await app.init()
+          await extraWait(PlatformAdapter, app)
+          await request(server)
+            .get('/')
+            .expect(200)
+            .expect((res) => {
+              expect(res.body).toHaveProperty('address', ETHERS_ADDRESS)
+            })
+
+          await app.close()
+        })
       })
     })
   }

--- a/__tests__/ethers.decorators.spec.ts
+++ b/__tests__/ethers.decorators.spec.ts
@@ -2,7 +2,20 @@ import { Module, Controller, Get, Injectable } from '@nestjs/common'
 import { NestFactory } from '@nestjs/core'
 import * as nock from 'nock'
 import * as request from 'supertest'
-import { EthersModule, InjectEthersProvider, BaseProvider, Network, MAINNET_NETWORK } from '../src'
+import {
+  EthersModule,
+  InjectEthersProvider,
+  InjectContractProvider,
+  InjectSignerProvider,
+  BaseProvider,
+  Network,
+  MAINNET_NETWORK,
+  EthersContract,
+  EthersSigner,
+  Contract,
+} from '../src'
+import * as ABI from './utils/ABI.json'
+import { ETHERS_ADDRESS } from './utils/constants'
 import { extraWait } from './utils/extraWait'
 import { platforms } from './utils/platforms'
 
@@ -24,91 +37,562 @@ describe('InjectEthersProvider', () => {
 
   for (const PlatformAdapter of platforms) {
     describe(PlatformAdapter.name, () => {
-      it('should inject ethers provider in a service successfully', async () => {
-        @Injectable()
-        class TestService {
-          constructor(
-            @InjectEthersProvider()
-            private readonly ethersProvider: BaseProvider,
-          ) {}
-          async someMethod(): Promise<Network> {
-            return this.ethersProvider.getNetwork()
+      describe('forRoot', () => {
+        it('should inject ethers provider in a service successfully', async () => {
+          @Injectable()
+          class TestService {
+            constructor(
+              @InjectEthersProvider()
+              private readonly ethersProvider: BaseProvider,
+            ) {}
+            async someMethod(): Promise<Network> {
+              return this.ethersProvider.getNetwork()
+            }
           }
-        }
 
-        @Controller('/')
-        class TestController {
-          constructor(private readonly service: TestService) {}
-          @Get()
-          async get() {
-            const network = await this.service.someMethod()
+          @Controller('/')
+          class TestController {
+            constructor(private readonly service: TestService) {}
+            @Get()
+            async get() {
+              const network = await this.service.someMethod()
 
-            return { network }
+              return { network }
+            }
           }
-        }
 
-        @Module({
-          imports: [EthersModule.forRoot()],
-          controllers: [TestController],
-          providers: [TestService],
-        })
-        class TestModule {}
-
-        const app = await NestFactory.create(TestModule, new PlatformAdapter(), { logger: false })
-        const server = app.getHttpServer()
-
-        await app.init()
-        await extraWait(PlatformAdapter, app)
-        await request(server)
-          .get('/')
-          .expect(200)
-          .expect((res) => {
-            expect(res.body.network).toBeDefined()
-            expect(res.body.network).toHaveProperty('name', MAINNET_NETWORK.name)
-            expect(res.body.network).toHaveProperty('chainId', 1)
-            expect(res.body.network).toHaveProperty('ensAddress')
+          @Module({
+            imports: [EthersModule.forRoot()],
+            controllers: [TestController],
+            providers: [TestService],
           })
+          class TestModule {}
 
-        await app.close()
+          const app = await NestFactory.create(TestModule, new PlatformAdapter(), { logger: false })
+          const server = app.getHttpServer()
+
+          await app.init()
+          await extraWait(PlatformAdapter, app)
+          await request(server)
+            .get('/')
+            .expect(200)
+            .expect((res) => {
+              expect(res.body.network).toBeDefined()
+              expect(res.body.network).toHaveProperty('name', MAINNET_NETWORK.name)
+              expect(res.body.network).toHaveProperty('chainId', 1)
+              expect(res.body.network).toHaveProperty('ensAddress')
+            })
+
+          await app.close()
+        })
+
+        it('should inject ethers provider in a controller successfully', async () => {
+          @Controller('/')
+          class TestController {
+            constructor(
+              @InjectEthersProvider()
+              private readonly ethersProvider: BaseProvider,
+            ) {}
+            @Get()
+            async get() {
+              const network = await this.ethersProvider.getNetwork()
+
+              return { network }
+            }
+          }
+
+          @Module({
+            imports: [EthersModule.forRoot()],
+            controllers: [TestController],
+          })
+          class TestModule {}
+
+          const app = await NestFactory.create(TestModule, new PlatformAdapter(), { logger: false })
+          const server = app.getHttpServer()
+
+          await app.init()
+          await extraWait(PlatformAdapter, app)
+          await request(server)
+            .get('/')
+            .expect(200)
+            .expect((res) => {
+              expect(res.body.network).toBeDefined()
+              expect(res.body.network).toHaveProperty('name', MAINNET_NETWORK.name)
+              expect(res.body.network).toHaveProperty('chainId', 1)
+              expect(res.body.network).toHaveProperty('ensAddress')
+            })
+
+          await app.close()
+        })
+
+        it('should inject contract provider in a service successfully', async () => {
+          @Injectable()
+          class TestService {
+            constructor(
+              @InjectContractProvider()
+              private readonly contract: EthersContract,
+            ) {}
+            async someMethod(): Promise<string> {
+              const contract: Contract = this.contract.create(ETHERS_ADDRESS, ABI)
+
+              return contract.address
+            }
+          }
+
+          @Controller('/')
+          class TestController {
+            constructor(private readonly service: TestService) {}
+            @Get()
+            async get() {
+              const address = await this.service.someMethod()
+
+              return { address: address.toLowerCase() }
+            }
+          }
+
+          @Module({
+            imports: [EthersModule.forRoot()],
+            controllers: [TestController],
+            providers: [TestService],
+          })
+          class TestModule {}
+
+          const app = await NestFactory.create(TestModule, new PlatformAdapter(), { logger: false })
+          const server = app.getHttpServer()
+
+          await app.init()
+          await extraWait(PlatformAdapter, app)
+          await request(server)
+            .get('/')
+            .expect(200)
+            .expect((res) => {
+              expect(res.body).toHaveProperty('address', ETHERS_ADDRESS)
+            })
+
+          await app.close()
+        })
+
+        it('should inject contract provider in a controller successfully', async () => {
+          @Controller('/')
+          class TestController {
+            constructor(
+              @InjectContractProvider()
+              private readonly contract: EthersContract,
+            ) {}
+            @Get()
+            async get() {
+              const contract: Contract = this.contract.create(ETHERS_ADDRESS, ABI)
+
+              return { address: contract.address.toLowerCase() }
+            }
+          }
+
+          @Module({
+            imports: [EthersModule.forRoot()],
+            controllers: [TestController],
+          })
+          class TestModule {}
+
+          const app = await NestFactory.create(TestModule, new PlatformAdapter(), { logger: false })
+          const server = app.getHttpServer()
+
+          await app.init()
+          await extraWait(PlatformAdapter, app)
+          await request(server)
+            .get('/')
+            .expect(200)
+            .expect((res) => {
+              expect(res.body).toHaveProperty('address', ETHERS_ADDRESS)
+            })
+
+          await app.close()
+        })
+
+        it('should inject signer provider in a service successfully', async () => {
+          @Injectable()
+          class TestService {
+            constructor(
+              @InjectSignerProvider()
+              private readonly signer: EthersSigner,
+            ) {}
+            async someMethod(): Promise<string> {
+              const wallet = this.signer.createVoidSigner(ETHERS_ADDRESS)
+
+              return wallet.getAddress()
+            }
+          }
+
+          @Controller('/')
+          class TestController {
+            constructor(private readonly service: TestService) {}
+            @Get()
+            async get() {
+              const address = await this.service.someMethod()
+
+              return { address: address.toLowerCase() }
+            }
+          }
+
+          @Module({
+            imports: [EthersModule.forRoot()],
+            controllers: [TestController],
+            providers: [TestService],
+          })
+          class TestModule {}
+
+          const app = await NestFactory.create(TestModule, new PlatformAdapter(), { logger: false })
+          const server = app.getHttpServer()
+
+          await app.init()
+          await extraWait(PlatformAdapter, app)
+          await request(server)
+            .get('/')
+            .expect(200)
+            .expect((res) => {
+              expect(res.body).toHaveProperty('address', ETHERS_ADDRESS)
+            })
+
+          await app.close()
+        })
+
+        it('should inject signer provider in a controller successfully', async () => {
+          @Controller('/')
+          class TestController {
+            constructor(
+              @InjectSignerProvider()
+              private readonly signer: EthersSigner,
+            ) {}
+            @Get()
+            async get() {
+              const wallet = this.signer.createVoidSigner(ETHERS_ADDRESS)
+
+              return { address: wallet.address.toLowerCase() }
+            }
+          }
+
+          @Module({
+            imports: [EthersModule.forRoot()],
+            controllers: [TestController],
+          })
+          class TestModule {}
+
+          const app = await NestFactory.create(TestModule, new PlatformAdapter(), { logger: false })
+          const server = app.getHttpServer()
+
+          await app.init()
+          await extraWait(PlatformAdapter, app)
+          await request(server)
+            .get('/')
+            .expect(200)
+            .expect((res) => {
+              expect(res.body).toHaveProperty('address', ETHERS_ADDRESS)
+            })
+
+          await app.close()
+        })
       })
 
-      it('should inject ethers provider in a controller successfully', async () => {
-        @Controller('/')
-        class TestController {
-          constructor(
-            @InjectEthersProvider()
-            private readonly ethersProvider: BaseProvider,
-          ) {}
-          @Get()
-          async get() {
-            const network = await this.ethersProvider.getNetwork()
-
-            return { network }
+      describe('forRootAsync', () => {
+        it('should inject ethers provider in a service successfully', async () => {
+          @Injectable()
+          class TestService {
+            constructor(
+              @InjectEthersProvider()
+              private readonly ethersProvider: BaseProvider,
+            ) {}
+            async someMethod(): Promise<Network> {
+              return this.ethersProvider.getNetwork()
+            }
           }
-        }
 
-        @Module({
-          imports: [EthersModule.forRoot()],
-          controllers: [TestController],
-        })
-        class TestModule {}
+          @Controller('/')
+          class TestController {
+            constructor(private readonly service: TestService) {}
+            @Get()
+            async get() {
+              const network = await this.service.someMethod()
 
-        const app = await NestFactory.create(TestModule, new PlatformAdapter(), { logger: false })
-        const server = app.getHttpServer()
+              return { network }
+            }
+          }
 
-        await app.init()
-        await extraWait(PlatformAdapter, app)
-        await request(server)
-          .get('/')
-          .expect(200)
-          .expect((res) => {
-            expect(res.body.network).toBeDefined()
-            expect(res.body.network).toHaveProperty('name', MAINNET_NETWORK.name)
-            expect(res.body.network).toHaveProperty('chainId', 1)
-            expect(res.body.network).toHaveProperty('ensAddress')
+          @Module({
+            imports: [
+              EthersModule.forRootAsync({
+                useFactory: () => {
+                  return {
+                    useDefaultProvider: true,
+                  }
+                },
+              }),
+            ],
+            controllers: [TestController],
+            providers: [TestService],
           })
+          class TestModule {}
 
-        await app.close()
+          const app = await NestFactory.create(TestModule, new PlatformAdapter(), { logger: false })
+          const server = app.getHttpServer()
+
+          await app.init()
+          await extraWait(PlatformAdapter, app)
+          await request(server)
+            .get('/')
+            .expect(200)
+            .expect((res) => {
+              expect(res.body.network).toBeDefined()
+              expect(res.body.network).toHaveProperty('name', MAINNET_NETWORK.name)
+              expect(res.body.network).toHaveProperty('chainId', 1)
+              expect(res.body.network).toHaveProperty('ensAddress')
+            })
+
+          await app.close()
+        })
+
+        it('should inject ethers provider in a controller successfully', async () => {
+          @Controller('/')
+          class TestController {
+            constructor(
+              @InjectEthersProvider()
+              private readonly ethersProvider: BaseProvider,
+            ) {}
+            @Get()
+            async get() {
+              const network = await this.ethersProvider.getNetwork()
+
+              return { network }
+            }
+          }
+
+          @Module({
+            imports: [
+              EthersModule.forRootAsync({
+                useFactory: () => {
+                  return {
+                    useDefaultProvider: true,
+                  }
+                },
+              }),
+            ],
+            controllers: [TestController],
+          })
+          class TestModule {}
+
+          const app = await NestFactory.create(TestModule, new PlatformAdapter(), { logger: false })
+          const server = app.getHttpServer()
+
+          await app.init()
+          await extraWait(PlatformAdapter, app)
+          await request(server)
+            .get('/')
+            .expect(200)
+            .expect((res) => {
+              expect(res.body.network).toBeDefined()
+              expect(res.body.network).toHaveProperty('name', MAINNET_NETWORK.name)
+              expect(res.body.network).toHaveProperty('chainId', 1)
+              expect(res.body.network).toHaveProperty('ensAddress')
+            })
+
+          await app.close()
+        })
+
+        it('should inject contract provider in a service successfully', async () => {
+          @Injectable()
+          class TestService {
+            constructor(
+              @InjectContractProvider()
+              private readonly contract: EthersContract,
+            ) {}
+            async someMethod(): Promise<string> {
+              const contract: Contract = this.contract.create(ETHERS_ADDRESS, ABI)
+
+              return contract.address
+            }
+          }
+
+          @Controller('/')
+          class TestController {
+            constructor(private readonly service: TestService) {}
+            @Get()
+            async get() {
+              const address = await this.service.someMethod()
+
+              return { address: address.toLowerCase() }
+            }
+          }
+
+          @Module({
+            imports: [
+              EthersModule.forRootAsync({
+                useFactory: () => {
+                  return {
+                    useDefaultProvider: true,
+                  }
+                },
+              }),
+            ],
+            controllers: [TestController],
+            providers: [TestService],
+          })
+          class TestModule {}
+
+          const app = await NestFactory.create(TestModule, new PlatformAdapter(), { logger: false })
+          const server = app.getHttpServer()
+
+          await app.init()
+          await extraWait(PlatformAdapter, app)
+          await request(server)
+            .get('/')
+            .expect(200)
+            .expect((res) => {
+              expect(res.body).toHaveProperty('address', ETHERS_ADDRESS)
+            })
+
+          await app.close()
+        })
+
+        it('should inject contract provider in a controller successfully', async () => {
+          @Controller('/')
+          class TestController {
+            constructor(
+              @InjectContractProvider()
+              private readonly contract: EthersContract,
+            ) {}
+            @Get()
+            async get() {
+              const contract: Contract = this.contract.create(ETHERS_ADDRESS, ABI)
+
+              return { address: contract.address.toLowerCase() }
+            }
+          }
+
+          @Module({
+            imports: [
+              EthersModule.forRootAsync({
+                useFactory: () => {
+                  return {
+                    useDefaultProvider: true,
+                  }
+                },
+              }),
+            ],
+            controllers: [TestController],
+          })
+          class TestModule {}
+
+          const app = await NestFactory.create(TestModule, new PlatformAdapter(), { logger: false })
+          const server = app.getHttpServer()
+
+          await app.init()
+          await extraWait(PlatformAdapter, app)
+          await request(server)
+            .get('/')
+            .expect(200)
+            .expect((res) => {
+              expect(res.body).toHaveProperty('address', ETHERS_ADDRESS)
+            })
+
+          await app.close()
+        })
+
+        it('should inject signer provider in a service successfully', async () => {
+          @Injectable()
+          class TestService {
+            constructor(
+              @InjectSignerProvider()
+              private readonly signer: EthersSigner,
+            ) {}
+            async someMethod(): Promise<string> {
+              const wallet = this.signer.createVoidSigner(ETHERS_ADDRESS)
+
+              return wallet.getAddress()
+            }
+          }
+
+          @Controller('/')
+          class TestController {
+            constructor(private readonly service: TestService) {}
+            @Get()
+            async get() {
+              const address = await this.service.someMethod()
+
+              return { address: address.toLowerCase() }
+            }
+          }
+
+          @Module({
+            imports: [
+              EthersModule.forRootAsync({
+                useFactory: () => {
+                  return {
+                    useDefaultProvider: true,
+                  }
+                },
+              }),
+            ],
+            controllers: [TestController],
+            providers: [TestService],
+          })
+          class TestModule {}
+
+          const app = await NestFactory.create(TestModule, new PlatformAdapter(), { logger: false })
+          const server = app.getHttpServer()
+
+          await app.init()
+          await extraWait(PlatformAdapter, app)
+          await request(server)
+            .get('/')
+            .expect(200)
+            .expect((res) => {
+              expect(res.body).toHaveProperty('address', ETHERS_ADDRESS)
+            })
+
+          await app.close()
+        })
+
+        it('should inject signer provider in a controller successfully', async () => {
+          @Controller('/')
+          class TestController {
+            constructor(
+              @InjectSignerProvider()
+              private readonly signer: EthersSigner,
+            ) {}
+            @Get()
+            async get() {
+              const wallet = this.signer.createVoidSigner(ETHERS_ADDRESS)
+
+              return { address: wallet.address.toLowerCase() }
+            }
+          }
+
+          @Module({
+            imports: [
+              EthersModule.forRootAsync({
+                useFactory: () => {
+                  return {
+                    useDefaultProvider: true,
+                  }
+                },
+              }),
+            ],
+            controllers: [TestController],
+          })
+          class TestModule {}
+
+          const app = await NestFactory.create(TestModule, new PlatformAdapter(), { logger: false })
+          const server = app.getHttpServer()
+
+          await app.init()
+          await extraWait(PlatformAdapter, app)
+          await request(server)
+            .get('/')
+            .expect(200)
+            .expect((res) => {
+              expect(res.body).toHaveProperty('address', ETHERS_ADDRESS)
+            })
+
+          await app.close()
+        })
       })
     })
   }

--- a/__tests__/ethers.signer.spec.ts
+++ b/__tests__/ethers.signer.spec.ts
@@ -2,7 +2,7 @@ import { Module, Controller, Get, Injectable } from '@nestjs/common'
 import { NestFactory } from '@nestjs/core'
 import * as nock from 'nock'
 import * as request from 'supertest'
-import { EthersModule, EthersSigner } from '../src'
+import { EthersModule, EthersSigner, InjectSignerProvider } from '../src'
 import {
   ETHERS_ADDRESS,
   ETHERS_PRIVATE_KEY,
@@ -31,247 +31,564 @@ describe('EthersSigner', () => {
 
   for (const PlatformAdapter of platforms) {
     describe(PlatformAdapter.name, () => {
-      it('should create a wallet from a private ket with a provider injected', async () => {
-        @Injectable()
-        class TestService {
-          constructor(private readonly ethersSigner: EthersSigner) {}
-          async someMethod(): Promise<string> {
-            const wallet = this.ethersSigner.createWallet(ETHERS_PRIVATE_KEY)
+      describe('forRoot', () => {
+        it('should create a wallet from a private ket with a provider injected', async () => {
+          @Injectable()
+          class TestService {
+            constructor(
+              @InjectSignerProvider()
+              private readonly signer: EthersSigner,
+            ) {}
+            async someMethod(): Promise<string> {
+              const wallet = this.signer.createWallet(ETHERS_PRIVATE_KEY)
 
-            if (!wallet?.provider?.getNetwork()) {
-              throw new Error('No provider injected')
+              if (!wallet?.provider?.getNetwork()) {
+                throw new Error('No provider injected')
+              }
+
+              return wallet.getAddress()
             }
-
-            return wallet.getAddress()
           }
-        }
 
-        @Controller('/')
-        class TestController {
-          constructor(private readonly service: TestService) {}
-          @Get()
-          async get() {
-            const address = await this.service.someMethod()
+          @Controller('/')
+          class TestController {
+            constructor(private readonly service: TestService) {}
+            @Get()
+            async get() {
+              const address = await this.service.someMethod()
 
-            return { address: address.toLowerCase() }
+              return { address: address.toLowerCase() }
+            }
           }
-        }
 
-        @Module({
-          imports: [EthersModule.forRoot()],
-          controllers: [TestController],
-          providers: [TestService],
-        })
-        class TestModule {}
-
-        const app = await NestFactory.create(TestModule, new PlatformAdapter(), { logger: false })
-        const server = app.getHttpServer()
-
-        await app.init()
-        await extraWait(PlatformAdapter, app)
-        await request(server)
-          .get('/')
-          .expect(200)
-          .expect((res) => {
-            expect(res.body).toHaveProperty('address', ETHERS_ADDRESS)
+          @Module({
+            imports: [EthersModule.forRoot()],
+            controllers: [TestController],
+            providers: [TestService],
           })
+          class TestModule {}
 
-        await app.close()
+          const app = await NestFactory.create(TestModule, new PlatformAdapter(), { logger: false })
+          const server = app.getHttpServer()
+
+          await app.init()
+          await extraWait(PlatformAdapter, app)
+          await request(server)
+            .get('/')
+            .expect(200)
+            .expect((res) => {
+              expect(res.body).toHaveProperty('address', ETHERS_ADDRESS)
+            })
+
+          await app.close()
+        })
+
+        it('should create a random wallet With a provider injected', async () => {
+          @Injectable()
+          class TestService {
+            constructor(
+              @InjectSignerProvider()
+              private readonly signer: EthersSigner,
+            ) {}
+            async someMethod(): Promise<string> {
+              const wallet = this.signer.createRandomWallet()
+
+              if (!wallet?.provider?.getNetwork()) {
+                throw new Error('No provider injected')
+              }
+
+              return wallet.getAddress()
+            }
+          }
+
+          @Controller('/')
+          class TestController {
+            constructor(private readonly service: TestService) {}
+            @Get()
+            async get() {
+              const address = await this.service.someMethod()
+
+              return { address }
+            }
+          }
+
+          @Module({
+            imports: [EthersModule.forRoot()],
+            controllers: [TestController],
+            providers: [TestService],
+          })
+          class TestModule {}
+
+          const app = await NestFactory.create(TestModule, new PlatformAdapter(), { logger: false })
+          const server = app.getHttpServer()
+
+          await app.init()
+          await extraWait(PlatformAdapter, app)
+          await request(server)
+            .get('/')
+            .expect(200)
+            .expect((res) => {
+              expect(res.body.address).toBeDefined()
+            })
+
+          await app.close()
+        })
+
+        it('should create a wallet from an encrypted JSON with a provider injected', async () => {
+          @Injectable()
+          class TestService {
+            constructor(
+              @InjectSignerProvider()
+              private readonly signer: EthersSigner,
+            ) {}
+            async someMethod(): Promise<string> {
+              const wallet = await this.signer.createWalletfromEncryptedJson(
+                ETHERS_JSON_WALLET,
+                ETHERS_JSON_WALLET_PASSWORD,
+              )
+
+              if (!wallet?.provider?.getNetwork()) {
+                throw new Error('No provider injected')
+              }
+
+              return wallet.getAddress()
+            }
+          }
+
+          @Controller('/')
+          class TestController {
+            constructor(private readonly service: TestService) {}
+            @Get()
+            async get() {
+              const address = await this.service.someMethod()
+
+              return { address: address.toLowerCase() }
+            }
+          }
+
+          @Module({
+            imports: [EthersModule.forRoot()],
+            controllers: [TestController],
+            providers: [TestService],
+          })
+          class TestModule {}
+
+          const app = await NestFactory.create(TestModule, new PlatformAdapter(), { logger: false })
+          const server = app.getHttpServer()
+
+          await app.init()
+          await extraWait(PlatformAdapter, app)
+          await request(server)
+            .get('/')
+            .expect(200)
+            .expect((res) => {
+              expect(res.body).toHaveProperty('address', ETHERS_ADDRESS)
+            })
+
+          await app.close()
+        })
+
+        it('should create a wallet from a mnemonic with a provider injected', async () => {
+          @Injectable()
+          class TestService {
+            constructor(
+              @InjectSignerProvider()
+              private readonly signer: EthersSigner,
+            ) {}
+            async someMethod(): Promise<string> {
+              const wallet = this.signer.createWalletfromMnemonic(ETHERS_MNEMONIC)
+
+              if (!wallet?.provider?.getNetwork()) {
+                throw new Error('No provider injected')
+              }
+
+              return wallet.getAddress()
+            }
+          }
+
+          @Controller('/')
+          class TestController {
+            constructor(private readonly service: TestService) {}
+            @Get()
+            async get() {
+              const address = await this.service.someMethod()
+
+              return { address: address.toLowerCase() }
+            }
+          }
+
+          @Module({
+            imports: [EthersModule.forRoot()],
+            controllers: [TestController],
+            providers: [TestService],
+          })
+          class TestModule {}
+
+          const app = await NestFactory.create(TestModule, new PlatformAdapter(), { logger: false })
+          const server = app.getHttpServer()
+
+          await app.init()
+          await extraWait(PlatformAdapter, app)
+          await request(server)
+            .get('/')
+            .expect(200)
+            .expect((res) => {
+              expect(res.body).toHaveProperty('address', ETHERS_ADDRESS)
+            })
+
+          await app.close()
+        })
+
+        it('should create a void signer from an address with a provider injected', async () => {
+          @Injectable()
+          class TestService {
+            constructor(
+              @InjectSignerProvider()
+              private readonly signer: EthersSigner,
+            ) {}
+            async someMethod(): Promise<string> {
+              const wallet = this.signer.createVoidSigner(ETHERS_ADDRESS)
+
+              if (!wallet?.provider?.getNetwork()) {
+                throw new Error('No provider injected')
+              }
+
+              return wallet.getAddress()
+            }
+          }
+
+          @Controller('/')
+          class TestController {
+            constructor(private readonly service: TestService) {}
+            @Get()
+            async get() {
+              const address = await this.service.someMethod()
+
+              return { address: address.toLowerCase() }
+            }
+          }
+
+          @Module({
+            imports: [EthersModule.forRoot()],
+            controllers: [TestController],
+            providers: [TestService],
+          })
+          class TestModule {}
+
+          const app = await NestFactory.create(TestModule, new PlatformAdapter(), { logger: false })
+          const server = app.getHttpServer()
+
+          await app.init()
+          await extraWait(PlatformAdapter, app)
+          await request(server)
+            .get('/')
+            .expect(200)
+            .expect((res) => {
+              expect(res.body).toHaveProperty('address', ETHERS_ADDRESS)
+            })
+
+          await app.close()
+        })
       })
 
-      it('should create a random wallet With a provider injected', async () => {
-        @Injectable()
-        class TestService {
-          constructor(private readonly ethersSigner: EthersSigner) {}
-          async someMethod(): Promise<string> {
-            const wallet = this.ethersSigner.createRandomWallet()
+      describe('forRootAsync', () => {
+        it('should create a wallet from a private ket with a provider injected', async () => {
+          @Injectable()
+          class TestService {
+            constructor(
+              @InjectSignerProvider()
+              private readonly signer: EthersSigner,
+            ) {}
+            async someMethod(): Promise<string> {
+              const wallet = this.signer.createWallet(ETHERS_PRIVATE_KEY)
 
-            if (!wallet?.provider?.getNetwork()) {
-              throw new Error('No provider injected')
+              if (!wallet?.provider?.getNetwork()) {
+                throw new Error('No provider injected')
+              }
+
+              return wallet.getAddress()
             }
-
-            return wallet.getAddress()
           }
-        }
 
-        @Controller('/')
-        class TestController {
-          constructor(private readonly service: TestService) {}
-          @Get()
-          async get() {
-            const address = await this.service.someMethod()
+          @Controller('/')
+          class TestController {
+            constructor(private readonly service: TestService) {}
+            @Get()
+            async get() {
+              const address = await this.service.someMethod()
 
-            return { address }
-          }
-        }
-
-        @Module({
-          imports: [EthersModule.forRoot()],
-          controllers: [TestController],
-          providers: [TestService],
-        })
-        class TestModule {}
-
-        const app = await NestFactory.create(TestModule, new PlatformAdapter(), { logger: false })
-        const server = app.getHttpServer()
-
-        await app.init()
-        await extraWait(PlatformAdapter, app)
-        await request(server)
-          .get('/')
-          .expect(200)
-          .expect((res) => {
-            expect(res.body.address).toBeDefined()
-          })
-
-        await app.close()
-      })
-
-      it('should create a wallet from an encrypted JSON with a provider injected', async () => {
-        @Injectable()
-        class TestService {
-          constructor(private readonly ethersSigner: EthersSigner) {}
-          async someMethod(): Promise<string> {
-            const wallet = await this.ethersSigner.createWalletfromEncryptedJson(
-              ETHERS_JSON_WALLET,
-              ETHERS_JSON_WALLET_PASSWORD,
-            )
-
-            if (!wallet?.provider?.getNetwork()) {
-              throw new Error('No provider injected')
+              return { address: address.toLowerCase() }
             }
-
-            return wallet.getAddress()
           }
-        }
 
-        @Controller('/')
-        class TestController {
-          constructor(private readonly service: TestService) {}
-          @Get()
-          async get() {
-            const address = await this.service.someMethod()
-
-            return { address: address.toLowerCase() }
-          }
-        }
-
-        @Module({
-          imports: [EthersModule.forRoot()],
-          controllers: [TestController],
-          providers: [TestService],
-        })
-        class TestModule {}
-
-        const app = await NestFactory.create(TestModule, new PlatformAdapter(), { logger: false })
-        const server = app.getHttpServer()
-
-        await app.init()
-        await extraWait(PlatformAdapter, app)
-        await request(server)
-          .get('/')
-          .expect(200)
-          .expect((res) => {
-            expect(res.body).toHaveProperty('address', ETHERS_ADDRESS)
+          @Module({
+            imports: [
+              EthersModule.forRootAsync({
+                useFactory: () => {
+                  return {
+                    useDefaultProvider: true,
+                  }
+                },
+              }),
+            ],
+            controllers: [TestController],
+            providers: [TestService],
           })
+          class TestModule {}
 
-        await app.close()
-      })
+          const app = await NestFactory.create(TestModule, new PlatformAdapter(), { logger: false })
+          const server = app.getHttpServer()
 
-      it('should create a wallet from a mnemonic with a provider injected', async () => {
-        @Injectable()
-        class TestService {
-          constructor(private readonly ethersSigner: EthersSigner) {}
-          async someMethod(): Promise<string> {
-            const wallet = this.ethersSigner.createWalletfromMnemonic(ETHERS_MNEMONIC)
+          await app.init()
+          await extraWait(PlatformAdapter, app)
+          await request(server)
+            .get('/')
+            .expect(200)
+            .expect((res) => {
+              expect(res.body).toHaveProperty('address', ETHERS_ADDRESS)
+            })
 
-            if (!wallet?.provider?.getNetwork()) {
-              throw new Error('No provider injected')
+          await app.close()
+        })
+
+        it('should create a random wallet With a provider injected', async () => {
+          @Injectable()
+          class TestService {
+            constructor(
+              @InjectSignerProvider()
+              private readonly signer: EthersSigner,
+            ) {}
+            async someMethod(): Promise<string> {
+              const wallet = this.signer.createRandomWallet()
+
+              if (!wallet?.provider?.getNetwork()) {
+                throw new Error('No provider injected')
+              }
+
+              return wallet.getAddress()
             }
-
-            return wallet.getAddress()
           }
-        }
 
-        @Controller('/')
-        class TestController {
-          constructor(private readonly service: TestService) {}
-          @Get()
-          async get() {
-            const address = await this.service.someMethod()
+          @Controller('/')
+          class TestController {
+            constructor(private readonly service: TestService) {}
+            @Get()
+            async get() {
+              const address = await this.service.someMethod()
 
-            return { address: address.toLowerCase() }
-          }
-        }
-
-        @Module({
-          imports: [EthersModule.forRoot()],
-          controllers: [TestController],
-          providers: [TestService],
-        })
-        class TestModule {}
-
-        const app = await NestFactory.create(TestModule, new PlatformAdapter(), { logger: false })
-        const server = app.getHttpServer()
-
-        await app.init()
-        await extraWait(PlatformAdapter, app)
-        await request(server)
-          .get('/')
-          .expect(200)
-          .expect((res) => {
-            expect(res.body).toHaveProperty('address', ETHERS_ADDRESS)
-          })
-
-        await app.close()
-      })
-
-      it('should create a void signer from an address with a provider injected', async () => {
-        @Injectable()
-        class TestService {
-          constructor(private readonly ethersSigner: EthersSigner) {}
-          async someMethod(): Promise<string> {
-            const wallet = this.ethersSigner.createVoidSigner(ETHERS_ADDRESS)
-
-            if (!wallet?.provider?.getNetwork()) {
-              throw new Error('No provider injected')
+              return { address }
             }
-
-            return wallet.getAddress()
           }
-        }
 
-        @Controller('/')
-        class TestController {
-          constructor(private readonly service: TestService) {}
-          @Get()
-          async get() {
-            const address = await this.service.someMethod()
-
-            return { address: address.toLowerCase() }
-          }
-        }
-
-        @Module({
-          imports: [EthersModule.forRoot()],
-          controllers: [TestController],
-          providers: [TestService],
-        })
-        class TestModule {}
-
-        const app = await NestFactory.create(TestModule, new PlatformAdapter(), { logger: false })
-        const server = app.getHttpServer()
-
-        await app.init()
-        await extraWait(PlatformAdapter, app)
-        await request(server)
-          .get('/')
-          .expect(200)
-          .expect((res) => {
-            expect(res.body).toHaveProperty('address', ETHERS_ADDRESS)
+          @Module({
+            imports: [
+              EthersModule.forRootAsync({
+                useFactory: () => {
+                  return {
+                    useDefaultProvider: true,
+                  }
+                },
+              }),
+            ],
+            controllers: [TestController],
+            providers: [TestService],
           })
+          class TestModule {}
 
-        await app.close()
+          const app = await NestFactory.create(TestModule, new PlatformAdapter(), { logger: false })
+          const server = app.getHttpServer()
+
+          await app.init()
+          await extraWait(PlatformAdapter, app)
+          await request(server)
+            .get('/')
+            .expect(200)
+            .expect((res) => {
+              expect(res.body.address).toBeDefined()
+            })
+
+          await app.close()
+        })
+
+        it('should create a wallet from an encrypted JSON with a provider injected', async () => {
+          @Injectable()
+          class TestService {
+            constructor(
+              @InjectSignerProvider()
+              private readonly signer: EthersSigner,
+            ) {}
+            async someMethod(): Promise<string> {
+              const wallet = await this.signer.createWalletfromEncryptedJson(
+                ETHERS_JSON_WALLET,
+                ETHERS_JSON_WALLET_PASSWORD,
+              )
+
+              if (!wallet?.provider?.getNetwork()) {
+                throw new Error('No provider injected')
+              }
+
+              return wallet.getAddress()
+            }
+          }
+
+          @Controller('/')
+          class TestController {
+            constructor(private readonly service: TestService) {}
+            @Get()
+            async get() {
+              const address = await this.service.someMethod()
+
+              return { address: address.toLowerCase() }
+            }
+          }
+
+          @Module({
+            imports: [
+              EthersModule.forRootAsync({
+                useFactory: () => {
+                  return {
+                    useDefaultProvider: true,
+                  }
+                },
+              }),
+            ],
+            controllers: [TestController],
+            providers: [TestService],
+          })
+          class TestModule {}
+
+          const app = await NestFactory.create(TestModule, new PlatformAdapter(), { logger: false })
+          const server = app.getHttpServer()
+
+          await app.init()
+          await extraWait(PlatformAdapter, app)
+          await request(server)
+            .get('/')
+            .expect(200)
+            .expect((res) => {
+              expect(res.body).toHaveProperty('address', ETHERS_ADDRESS)
+            })
+
+          await app.close()
+        })
+
+        it('should create a wallet from a mnemonic with a provider injected', async () => {
+          @Injectable()
+          class TestService {
+            constructor(
+              @InjectSignerProvider()
+              private readonly signer: EthersSigner,
+            ) {}
+            async someMethod(): Promise<string> {
+              const wallet = this.signer.createWalletfromMnemonic(ETHERS_MNEMONIC)
+
+              if (!wallet?.provider?.getNetwork()) {
+                throw new Error('No provider injected')
+              }
+
+              return wallet.getAddress()
+            }
+          }
+
+          @Controller('/')
+          class TestController {
+            constructor(private readonly service: TestService) {}
+            @Get()
+            async get() {
+              const address = await this.service.someMethod()
+
+              return { address: address.toLowerCase() }
+            }
+          }
+
+          @Module({
+            imports: [
+              EthersModule.forRootAsync({
+                useFactory: () => {
+                  return {
+                    useDefaultProvider: true,
+                  }
+                },
+              }),
+            ],
+            controllers: [TestController],
+            providers: [TestService],
+          })
+          class TestModule {}
+
+          const app = await NestFactory.create(TestModule, new PlatformAdapter(), { logger: false })
+          const server = app.getHttpServer()
+
+          await app.init()
+          await extraWait(PlatformAdapter, app)
+          await request(server)
+            .get('/')
+            .expect(200)
+            .expect((res) => {
+              expect(res.body).toHaveProperty('address', ETHERS_ADDRESS)
+            })
+
+          await app.close()
+        })
+
+        it('should create a void signer from an address with a provider injected', async () => {
+          @Injectable()
+          class TestService {
+            constructor(
+              @InjectSignerProvider()
+              private readonly signer: EthersSigner,
+            ) {}
+            async someMethod(): Promise<string> {
+              const wallet = this.signer.createVoidSigner(ETHERS_ADDRESS)
+
+              if (!wallet?.provider?.getNetwork()) {
+                throw new Error('No provider injected')
+              }
+
+              return wallet.getAddress()
+            }
+          }
+
+          @Controller('/')
+          class TestController {
+            constructor(private readonly service: TestService) {}
+            @Get()
+            async get() {
+              const address = await this.service.someMethod()
+
+              return { address: address.toLowerCase() }
+            }
+          }
+
+          @Module({
+            imports: [
+              EthersModule.forRootAsync({
+                useFactory: () => {
+                  return {
+                    useDefaultProvider: true,
+                  }
+                },
+              }),
+            ],
+            controllers: [TestController],
+            providers: [TestService],
+          })
+          class TestModule {}
+
+          const app = await NestFactory.create(TestModule, new PlatformAdapter(), { logger: false })
+          const server = app.getHttpServer()
+
+          await app.init()
+          await extraWait(PlatformAdapter, app)
+          await request(server)
+            .get('/')
+            .expect(200)
+            .expect((res) => {
+              expect(res.body).toHaveProperty('address', ETHERS_ADDRESS)
+            })
+
+          await app.close()
+        })
       })
     })
   }

--- a/__tests__/utils/constants.ts
+++ b/__tests__/utils/constants.ts
@@ -1,7 +1,7 @@
 import { randomBytes } from 'crypto'
 
-export const RINKEBY_ALCHEMY_BASE_URL = 'https://eth-rinkeby.alchemyapi.io/v2'
-export const RINKEBY_ALCHEMY_POKT_URL = 'https://eth-rinkeby.gateway.pokt.network/v1'
+export const RINKEBY_ALCHEMY_URL = 'https://eth-rinkeby.alchemyapi.io/v2'
+export const RINKEBY_POCKET_URL = 'https://eth-rinkeby.gateway.pokt.network/v1'
 export const RINKEBY_ETHERSCAN_URL = 'https://api-rinkeby.etherscan.io/api'
 export const RINKEBY_INFURA_URL = 'https://rinkeby.infura.io/v3'
 export const CLOUDFLARE_URL = 'https://cloudflare-eth.com'
@@ -9,6 +9,7 @@ export const TESTNET_BSCSCAN_URL = 'http://api-testnet.bscscan.com/api'
 export const CUSTOM_BSC_1_URL = 'https://data-seed-prebsc-1-s1.binance.org:8545'
 export const CUSTOM_BSC_2_URL = 'https://data-seed-prebsc-1-s3.binance.org:8545'
 export const CUSTOM_BSC_3_URL = 'https://data-seed-prebsc-2-s2.binance.org:8545'
+export const MUMBAI_ALCHEMY_URL = 'https://polygon-mumbai.g.alchemy.com/v2/'
 export const RINKEBY_ETHERSCAN_API_KEY = randomBytes(17).toString('hex')
 export const RINKEBY_ALCHEMY_API_KEY = randomBytes(16).toString('hex')
 export const RINKEBY_POKT_API_KEY = randomBytes(12).toString('hex')

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nestjs-ethers",
-  "version": "1.0.0-beta.1",
+  "version": "1.0.0-beta.2",
   "description": "The ethers.js library for NestJS",
   "author": "Jose Ramirez <jarcodallo@gmail.com>",
   "license": "Apache",
@@ -80,7 +80,7 @@
   },
   "jest": {
     "verbose": true,
-    "testTimeout": 20000,
+    "testTimeout": 80000,
     "moduleFileExtensions": [
       "js",
       "json",

--- a/src/ethers.constants.ts
+++ b/src/ethers.constants.ts
@@ -1,8 +1,8 @@
 import { Network } from '@ethersproject/providers'
 
 export const DECORATED_PREFIX = 'EthersJS'
-export const ETHERS_PROVIDER_NAME = 'EthersProviderName'
 export const ETHERS_MODULE_OPTIONS = 'EthersModuleOptions'
+export const DEFAULT_TOKEN = 'default'
 export const HOMESTEAD_NETWORK: Network = {
   chainId: 1,
   name: 'homestead',

--- a/src/ethers.contract.ts
+++ b/src/ethers.contract.ts
@@ -1,23 +1,16 @@
 import { VoidSigner } from '@ethersproject/abstract-signer'
 import { Contract, ContractInterface } from '@ethersproject/contracts'
-import { BaseProvider } from '@ethersproject/providers'
+import { Provider as AbstractProvider } from '@ethersproject/providers'
 import { Wallet } from '@ethersproject/wallet'
-import { Injectable } from '@nestjs/common'
-import { InjectEthersProvider } from './ethers.decorators'
 
-export class SmartContract extends Contract {
-  constructor(address: string, abi: ContractInterface, provider: BaseProvider, signer?: Wallet | VoidSigner) {
-    const signerOrProvider: BaseProvider | Wallet | VoidSigner = signer ?? provider
-
-    super(address, abi, signerOrProvider)
-  }
-}
-
-@Injectable()
 export class EthersContract {
-  constructor(@InjectEthersProvider() private readonly provider: BaseProvider) {}
+  private readonly provider: AbstractProvider
 
-  create(address: string, abi: ContractInterface, signer?: Wallet | VoidSigner): SmartContract {
-    return new SmartContract(address, abi, this.provider, signer)
+  constructor(provider: AbstractProvider) {
+    this.provider = provider
+  }
+
+  create(address: string, abi: ContractInterface, signer?: Wallet | VoidSigner): Contract {
+    return new Contract(address, abi, signer ?? this.provider)
   }
 }

--- a/src/ethers.decorators.ts
+++ b/src/ethers.decorators.ts
@@ -1,4 +1,14 @@
 import { Inject } from '@nestjs/common'
-import { getEthersToken } from './ethers.utils'
+import { getContractToken, getEthersToken, getSigneroken } from './ethers.utils'
 
-export const InjectEthersProvider = () => Inject(getEthersToken())
+export const InjectEthersProvider = (token?: string) => {
+  return Inject(getEthersToken(token))
+}
+
+export const InjectContractProvider = (token?: string) => {
+  return Inject(getContractToken(token))
+}
+
+export const InjectSignerProvider = (token?: string) => {
+  return Inject(getSigneroken(token))
+}

--- a/src/ethers.interface.ts
+++ b/src/ethers.interface.ts
@@ -26,12 +26,14 @@ export interface EthersModuleOptions extends Record<string, any> {
   bscscan?: string | undefined
   custom?: ConnectionInfo | string | (ConnectionInfo | string)[] | undefined
   quorum?: number | undefined
+  token?: string | undefined
   waitUntilIsConnected?: boolean | undefined
   useDefaultProvider?: boolean | undefined
 }
 
 export interface EthersModuleAsyncOptions extends Pick<ModuleMetadata, 'imports' | 'providers'> {
-  useFactory: (...args: any[]) => EthersModuleOptions | Promise<EthersModuleOptions>
+  token?: string | undefined
+  useFactory: (...args: any[]) => Omit<EthersModuleOptions, 'token'> | Promise<Omit<EthersModuleOptions, 'token'>>
   inject?: any[]
 }
 

--- a/src/ethers.signer.ts
+++ b/src/ethers.signer.ts
@@ -1,17 +1,18 @@
 import { ExternallyOwnedAccount, VoidSigner } from '@ethersproject/abstract-signer'
 import { BytesLike } from '@ethersproject/bytes'
 import { ProgressCallback } from '@ethersproject/json-wallets'
-import { BaseProvider } from '@ethersproject/providers'
+import { Provider as AbstractProvider } from '@ethersproject/providers'
 import { SigningKey } from '@ethersproject/signing-key'
 import { Wallet } from '@ethersproject/wallet'
 import { Wordlist } from '@ethersproject/wordlists'
-import { Injectable } from '@nestjs/common'
-import { InjectEthersProvider } from './ethers.decorators'
 import { RandomWalletOptions } from './ethers.interface'
 
-@Injectable()
 export class EthersSigner {
-  constructor(@InjectEthersProvider() private readonly provider: BaseProvider) {}
+  private readonly provider: AbstractProvider
+
+  constructor(provider: AbstractProvider) {
+    this.provider = provider
+  }
 
   createWallet(privateKey: BytesLike | ExternallyOwnedAccount | SigningKey): Wallet {
     return new Wallet(privateKey, this.provider)

--- a/src/ethers.utils.ts
+++ b/src/ethers.utils.ts
@@ -1,5 +1,13 @@
-import { DECORATED_PREFIX } from './ethers.constants'
+import { DECORATED_PREFIX, DEFAULT_TOKEN } from './ethers.constants'
 
-export function getEthersToken(): string {
-  return `${DECORATED_PREFIX}:Provider`
+export function getEthersToken(token?: string): string {
+  return `${DECORATED_PREFIX}:Provider:${token || DEFAULT_TOKEN}`
+}
+
+export function getContractToken(token?: string): string {
+  return `${DECORATED_PREFIX}:Contract:${token || DEFAULT_TOKEN}`
+}
+
+export function getSigneroken(token?: string): string {
+  return `${DECORATED_PREFIX}:Signer:${token || DEFAULT_TOKEN}`
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 export { EthersModule } from './ethers.module'
-export { InjectEthersProvider } from './ethers.decorators'
+export { InjectEthersProvider, InjectContractProvider, InjectSignerProvider } from './ethers.decorators'
 export {
   InfuraProviderOptions,
   PocketProviderOptions,
@@ -30,9 +30,9 @@ export {
   BINANCE_NETWORK,
   BINANCE_TESTNET_NETWORK,
 } from './ethers.constants'
-export { getEthersToken } from './ethers.utils'
+export { getEthersToken, getContractToken, getSigneroken } from './ethers.utils'
 export { EthersSigner } from './ethers.signer'
-export { SmartContract, EthersContract } from './ethers.contract'
+export { EthersContract } from './ethers.contract'
 export * from '@ethersproject/abi'
 export * from '@ethersproject/abstract-provider'
 export * from '@ethersproject/abstract-signer'


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/jarcodallo/nestjs-ethers/blob/master/CONTRIBUTING.md
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
- [ ] Bugfix
- [x] Feature
- [x] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?
<!-- Please describe how the issue was solved. -->

- `EthersSigner` and `EthersContract` are not longer part of the global export. Now these two provider are injected in `forRoot` and `forRootAsync`.
- `@InjectContractProvider`  decorator declares the `EthersContract` class as a class that can be managed by the Nest IoC container.
- `@InjectSignerProvider` decorator declares the `EthersSigner` class as a class that can be managed by the Nest IoC .

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
